### PR TITLE
Call netdata as entrypoint with nodeamon arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM debian:jessie
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update
 
 ADD build.sh /build.sh
-ADD run.sh /run.sh
 
 RUN chmod +x /run.sh /build.sh; sync; sleep 1; /build.sh
 
@@ -12,4 +11,4 @@ WORKDIR /
 ENV NETDATA_PORT 19999
 EXPOSE $NETDATA_PORT
 
-ENTRYPOINT ["/run.sh"]
+ENTRYPOINT ["/usr/sbin/netdata", "-nd", "-ch", "/host", "-p", "${NETDATA_PORT}"]

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-/usr/sbin/netdata -ch /host -p ${NETDATA_PORT}
-sleep infinity


### PR DESCRIPTION
I've added the call to netdata bin inside the Dockerfile. That prevents the use of run.sh. Also now netdata get signals as it is the main process inside the container and not run.sh (which is sleeping) anymore.
