### PR TITLE
Allow health, chart, config overrides at any depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Alternatively, if you already have s sSMTP config, you can use that config with:
 
 See the following link for details on setting up sSMTP: [SSMTP - ArchWiki](https://wiki.archlinux.org/index.php/SSMTP)
 
+# Adding custom alarms, charts and configuration overrides
+
+To add custom alarms, charts or to override any default configuration file, mount a volume to the container to /etc/netdata/overrides, like `-v /opt/netdata/overrides:/etc/netdata/overrides`.  Then, place your config files in the directory as if it was /etc/netdata/.  
+
+For example to create a custom alarm for system temperature, create a `health.d` folder in your local directory (`/opt/netdata/overrides` in the example above) and place a `sensors.conf` file with your alarm configuration inside the `health.d` directory.
+
 # Getting alarms in Slack
 
 Netdata supports sending alerts to slack via webhooks. You can set that up by setting the following ENV variables:

--- a/releases/latest/scripts/run.sh
+++ b/releases/latest/scripts/run.sh
@@ -93,7 +93,7 @@ if [[ -d "/fakenet/" ]]; then
 fi
 
 for f in /etc/netdata/override/*; do
-  cp $f /etc/netdata/
+  cp -a $f /etc/netdata/
 done
 
 # main entrypoint


### PR DESCRIPTION
Adding an `-a` switch to the `cp` command allows you to create, for example, a `health.d/sensors.conf` and the run script will copy the file to the correct location.

One possible issue is the file is copied as the run script user, which in my case was root but that's mostly cosmetic as it functions the same.

Also added a blurb to the README about how to use this functionality.