### PR TITLE
Replace sSMTP with msmtp

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,27 +70,27 @@ If you need to pass some custom options to netdata, you can pass the following e
 
 Netdata supports forwarding alarms to an email address. You can set up sSMTP by setting the following ENV variables:
 
-- SSMTP_TO - This is the address alarms will be delivered to.
-- SSMTP_SERVER - This is your SMTP server. Defaults to smtp.gmail.com.
-- SSMTP_PORT - This is the SMTP server port. Defaults to 587.
-- SSMTP_USER - This is your username for the SMTP server.
-- SSMTP_PASS - This is your password for the SMTP server. Use an app password if using Gmail.
-- SSMTP_TLS - Use TLS for the connection. Defaults to YES.
-- SSMTP_HOSTNAME - The hostname mail will come from. Defaults to localhost.
+- SMTP_TO - This is the address alarms will be delivered to.
+- SMTP_SERVER - This is your SMTP server. Defaults to smtp.gmail.com.
+- SMTP_PORT - This is the SMTP server port. Defaults to 587.
+- SMTP_USER - This is your username for the SMTP server.
+- SMTP_PASS - This is your password for the SMTP server. Use an app password if using Gmail.
+- SMTP_TLS - Use TLS for the connection. Defaults to YES.
+- SMTP_HOSTNAME - The hostname mail will come from. Defaults to localhost.
 
 For example, using gmail:
 
 ```
--e SSMTP_TO=user@gmail.com -e SSMTP_USER=user -e SSMTP_PASS=password
+-e SMTP_TO=user@gmail.com -e SMTP_USER=user -e SMTP_PASS=password
 ```
 
-Alternatively, if you already have s sSMTP config, you can use that config with:
+Alternatively, if you already have s msmtp config, you can use that config with:
 
 ~~~
--v /path/to/config:/etc/ssmtp
+-v /path/to/msmtprc:/etc/msmtprc
 ~~~
 
-See the following link for details on setting up sSMTP: [SSMTP - ArchWiki](https://wiki.archlinux.org/index.php/SSMTP)
+See the following link for details on setting up sSMTP: [MSMTP - ArchWiki](https://wiki.archlinux.org/index.php/Msmtp)
 
 # Adding custom alarms, charts and configuration overrides
 

--- a/releases/latest/Dockerfile
+++ b/releases/latest/Dockerfile
@@ -9,7 +9,7 @@ RUN chmod +x /run.sh /build.sh && sync && sleep 1 && /build.sh
 
 WORKDIR /
 
-ENV NETDATA_PORT=19999 SSMTP_TLS=YES SSMTP_SERVER=smtp.gmail.com SSMTP_PORT=587 SSMTP_HOSTNAME=localhost
+ENV NETDATA_PORT=19999 SMTP_TLS=on SMTP_STARTTLS=on SMTP_SERVER=smtp.gmail.com SMTP_PORT=587
 EXPOSE $NETDATA_PORT
 
 VOLUME /etc/netdata/override

--- a/releases/latest/scripts/build.sh
+++ b/releases/latest/scripts/build.sh
@@ -12,7 +12,7 @@ echo "deb http://security.debian.org/debian-security jessie/updates main" >> /et
 apt-get -qq update
 apt-get -y install zlib1g-dev uuid-dev libmnl-dev gcc make curl git autoconf autogen automake pkg-config netcat-openbsd jq
 apt-get -y install autoconf-archive lm-sensors nodejs python python-mysqldb python-yaml
-apt-get -y install ssmtp mailutils apcupsd fping
+apt-get -y install msmtp msmtp-mta apcupsd fping
 
 # fetch netdata
 

--- a/releases/latest/scripts/run.sh
+++ b/releases/latest/scripts/run.sh
@@ -4,31 +4,34 @@
 chown root:root /usr/share/netdata/web/ -R
 echo -n "" > /usr/share/netdata/web/version.txt
 
-# set up ssmtp
-if [[ $SSMTP_TO ]]; then
-cat << EOF > /etc/ssmtp/ssmtp.conf
-root=$SSMTP_TO
-mailhub=$SSMTP_SERVER:$SSMTP_PORT
-UseSTARTTLS=$SSMTP_TLS
-hostname=$SSMTP_HOSTNAME
-FromLineOverride=NO
+# set up msmtp
+if [[ $SMTP_TO ]]; then
+cat << EOF > /etc/msmtprc
+account default
+aliases /etc/msmtp_aliases
+from $SMTP_TO
+host $SMTP_SERVER
+port $SMTP_PORT
+tls $SMTP_TLS
+tls_starttls $SMTP_STARTTLS
+tls_certcheck off
 EOF
 
-cat << EOF > /etc/ssmtp/revaliases
-netdata:netdata@$SSMTP_HOSTNAME:$SSMTP_SERVER:$SSMTP_PORT
-root:netdata@$SSMTP_HOSTNAME:$SSMTP_SERVER:$SSMTP_PORT
-EOF
-fi
-
-if [[ $SSMTP_USER ]]; then
-cat << EOF >> /etc/ssmtp/ssmtp.conf
-AuthUser=$SSMTP_USER
+cat << EOF > /etc/msmtp_aliases
+netdata: $SMTP_TO
+root: $SMTP_TO
 EOF
 fi
 
-if [[ $SSMTP_PASS ]]; then
-cat << EOF >> /etc/ssmtp/ssmtp.conf
-AuthPass=$SSMTP_PASS
+if [[ $SMTP_USER ]]; then
+cat << EOF >> /etc/msmtprc
+user $SMTP_USER
+EOF
+fi
+
+if [[ $SMTP_PASS ]]; then
+cat << EOF >> /etc/msmtprc
+password $SMTP_PASS
 EOF
 fi
 

--- a/releases/v1.10.0/README.md
+++ b/releases/v1.10.0/README.md
@@ -68,31 +68,29 @@ If you need to pass some custom options to netdata, you can pass the following e
 
 # Getting emails on alarms
 
-Netdata supports forwarding alarms to an email address. You can set up msmtp by setting the following ENV variables:
+Netdata supports forwarding alarms to an email address. You can set up sSMTP by setting the following ENV variables:
 
-- SMTP_TO - This is the address alarms will be delivered to.
-- SMTP_SERVER - This is your SMTP server. Defaults to smtp.gmail.com.
-- SMTP_PORT - This is the SMTP server port. Defaults to 587.
-- SMTP_USER - This is your username for the SMTP server.
-- SMTP_PASS - This is your password for the SMTP server. Use an app password if using Gmail.
-- SMTP_TLS - Use TLS for the connection. Defaults to `on`.
-- SMTP_STARTTLS - Use STARTTLS for the connection. Defaults to `on`.
+- SSMTP_TO - This is the address alarms will be delivered to.
+- SSMTP_SERVER - This is your SMTP server. Defaults to smtp.gmail.com.
+- SSMTP_PORT - This is the SMTP server port. Defaults to 587.
+- SSMTP_USER - This is your username for the SMTP server.
+- SSMTP_PASS - This is your password for the SMTP server. Use an app password if using Gmail.
+- SSMTP_TLS - Use TLS for the connection. Defaults to YES.
+- SSMTP_HOSTNAME - The hostname mail will come from. Defaults to localhost.
 
 For example, using gmail:
 
 ```
--e SMTP_TO=user@gmail.com -e SMTP_USER=user -e SMTP_PASS=password
+-e SSMTP_TO=user@gmail.com -e SSMTP_USER=user -e SSMTP_PASS=password
 ```
 
-Alternatively, if you already have s msmtp config, you can use that config with:
+Alternatively, if you already have s sSMTP config, you can use that config with:
 
 ~~~
--v /path/to/msmtprc:/etc/msmtprc
+-v /path/to/config:/etc/ssmtp
 ~~~
 
-See the following link for details on setting up msmtp: [MSMTP - ArchWiki](https://wiki.archlinux.org/index.php/Msmtp)
-
-> Note: email settings up to version v0.10.0 were different. You can get the [old documentation](https://github.com/titpetric/netdata/blob/master/releases/v0.10.0/README.md) is the corresponding release subfolder.
+See the following link for details on setting up sSMTP: [SSMTP - ArchWiki](https://wiki.archlinux.org/index.php/SSMTP)
 
 # Adding custom alarms, charts and configuration overrides
 
@@ -271,9 +269,3 @@ What you do get (even with the docker version) is:
 You will not get detailed application metrics (mysql, ups, etc.) from other containers or from the host if running netdata in a container. It may be possible to get *some* of those metrics, but it might not be easy, and most likely not worth it. For most detailed metrics, netdata needs to share the same environment as the application server it monitors. This means it would need to run either in the same container (not even remotely practical), or in the same virtual machine (no containers).
 
 > Note: if you have some custom hardware like a UPS which is monitored via USB and netdata supports it, you will most likely need to add new software to the netdata docker image to support it. The correct way to do it is to create your own Dockerfile, start with "FROM titpetric/netdata" and then add all your installation commands to build your own image which will support your hardware setup. Most likely if it's not a very common setup (i.e. available on most machines), the software will not be added to `titpetric/netdata` - that being said, your use case might be useful for others so feel free to submit issues with your extensions or feature requests in terms of new software. I'll gladly add your project/extension to the README here.
-
-# Changelog
-
-### v1.10.0 -> Latest
-
-* Replaced sSMTP with msmtp, renamed `SSMTP_*` settings as `SMTP_*`, removed `SSMTP_HOSTNAME` setting, renamed `SSMTP_TLS` to `SMTP_STARTTLS` and added `SMTP_TLS`.


### PR DESCRIPTION
Hello,

This is just because sSMTP is now unmaintained. Also, it seems that msmtp supports more ciphers and protocols.

In addition to replacing sSMTP with msmtp, this pull request renames all `SSMTP_*` settings as `SMTP_*` and removes the `SSMTP_HOSTNAME` setting. It also creates two distinct `SMTP_TLS` and `SMTP_STARTTLS` settings.

I only tested this with no authentication (without `SMTP_USER` and `SMTP_PASS`), but it should work fine with authentication as well.