### PR TITLE
fix #78: Alarm notification broken (since v1.11.0)

### DIFF
--- a/releases/latest/scripts/run.sh
+++ b/releases/latest/scripts/run.sh
@@ -36,6 +36,9 @@ password $SMTP_PASS
 EOF
 fi
 
+# copy conf from NETDATA_STOCK_CONFIG_DIR (normally under /usr/lib/netdata/conf.d) to NETDATA_USER_CONFIG_DIR (normally under /etc/netdata)
+cp /usr/lib/netdata/conf.d/health_alarm_notify.conf /etc/netdata
+
 if [[ $SLACK_WEBHOOK_URL ]]; then
 	sed -i -e "s@SLACK_WEBHOOK_URL=\"\"@SLACK_WEBHOOK_URL=\"${SLACK_WEBHOOK_URL}\"@" /etc/netdata/health_alarm_notify.conf
 fi

--- a/releases/v1.11.0/scripts/run.sh
+++ b/releases/v1.11.0/scripts/run.sh
@@ -36,6 +36,9 @@ password $SMTP_PASS
 EOF
 fi
 
+# copy conf from NETDATA_STOCK_CONFIG_DIR (normally under /usr/lib/netdata/conf.d) to NETDATA_USER_CONFIG_DIR (normally under /etc/netdata)
+cp /usr/lib/netdata/conf.d/health_alarm_notify.conf /etc/netdata
+
 if [[ $SLACK_WEBHOOK_URL ]]; then
 	sed -i -e "s@SLACK_WEBHOOK_URL=\"\"@SLACK_WEBHOOK_URL=\"${SLACK_WEBHOOK_URL}\"@" /etc/netdata/health_alarm_notify.conf
 fi

--- a/releases/v1.11.1/scripts/run.sh
+++ b/releases/v1.11.1/scripts/run.sh
@@ -36,6 +36,9 @@ password $SMTP_PASS
 EOF
 fi
 
+# copy conf from NETDATA_STOCK_CONFIG_DIR (normally under /usr/lib/netdata/conf.d) to NETDATA_USER_CONFIG_DIR (normally under /etc/netdata)
+cp /usr/lib/netdata/conf.d/health_alarm_notify.conf /etc/netdata
+
 if [[ $SLACK_WEBHOOK_URL ]]; then
 	sed -i -e "s@SLACK_WEBHOOK_URL=\"\"@SLACK_WEBHOOK_URL=\"${SLACK_WEBHOOK_URL}\"@" /etc/netdata/health_alarm_notify.conf
 fi

--- a/releases/v1.12.0-rc0/scripts/run.sh
+++ b/releases/v1.12.0-rc0/scripts/run.sh
@@ -36,6 +36,9 @@ password $SMTP_PASS
 EOF
 fi
 
+# copy conf from NETDATA_STOCK_CONFIG_DIR (normally under /usr/lib/netdata/conf.d) to NETDATA_USER_CONFIG_DIR (normally under /etc/netdata)
+cp /usr/lib/netdata/conf.d/health_alarm_notify.conf /etc/netdata
+
 if [[ $SLACK_WEBHOOK_URL ]]; then
 	sed -i -e "s@SLACK_WEBHOOK_URL=\"\"@SLACK_WEBHOOK_URL=\"${SLACK_WEBHOOK_URL}\"@" /etc/netdata/health_alarm_notify.conf
 fi


### PR DESCRIPTION
Fix "alarm notification broken" issue for 1.11.0, 1.11.1, and 1.12.0-rc0.

Test builds can be found on docker hub: https://hub.docker.com/r/tarlety/netdata.