### PR TITLE
patch out spyware

### DIFF
--- a/releases/latest/scripts/build.sh
+++ b/releases/latest/scripts/build.sh
@@ -28,7 +28,7 @@ fi
 
 # use the provided installer
 
-./netdata-installer.sh --dont-wait --dont-start-it
+./netdata-installer.sh --dont-wait --dont-start-it --disable-telemetry
 
 # removed hack on 2017/1/3
 #chown root:root /usr/libexec/netdata/plugins.d/apps.plugin


### PR DESCRIPTION
This argument is required to keep netdata from sending your personally identifiable information back to Google.

more info: https://docs.netdata.cloud/docs/anonymous-statistics/

(They claim it's anonymous, but it can't be: it includes your IP address.)